### PR TITLE
Fix the unsigned macOS build failing on an empty CSC_LINK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,16 @@ jobs:
     # GitHub doing that. Public repo, public logs.
     - name: Build Electron app (macOS)
       if: runner.os == 'macOS'
+      # shell: bash is what supplies pipefail. The default shell is `bash -e`
+      # without it, so a failing build piped into sed would report success and
+      # only surface as a missing artifact later
+      shell: bash
       run: |
+        # An empty CSC_LINK is not the same as an unset one: electron-builder
+        # reads it as a path to the certificate, resolves it to the project
+        # directory and dies with "not a file". Unsigned runs land here because
+        # a GitHub expression that evaluates to nothing still defines the var.
+        if [ -z "$CSC_LINK" ]; then unset CSC_LINK CSC_KEY_PASSWORD; fi
         if [ -n "$SIGNING_IDENTITY_NAME" ]; then
           npm run electron:build -- --publish never 2>&1 | sed "s/$SIGNING_IDENTITY_NAME/***/g"
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,16 @@ jobs:
     # GitHub doing that. Public repo, public logs.
     - name: Build Electron app (macOS)
       if: runner.os == 'macOS'
+      # shell: bash is what supplies pipefail. The default shell is `bash -e`
+      # without it, so a failing build piped into sed would report success and
+      # only surface as a missing artifact later
+      shell: bash
       run: |
+        # An empty CSC_LINK is not the same as an unset one: electron-builder
+        # reads it as a path to the certificate, resolves it to the project
+        # directory and dies with "not a file". Unsigned runs land here because
+        # a GitHub expression that evaluates to nothing still defines the var.
+        if [ -z "$CSC_LINK" ]; then unset CSC_LINK CSC_KEY_PASSWORD; fi
         if [ -n "$SIGNING_IDENTITY_NAME" ]; then
           npm run electron:build -- --publish never 2>&1 | sed "s/$SIGNING_IDENTITY_NAME/***/g"
         else


### PR DESCRIPTION
The macOS job on `main` fails with `No files were found with the provided path: dist/*.dmg`. The upload is a symptom; the build had already failed.

```
• empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
⨯ /Users/runner/work/Vigil/Vigil not a file
```

**Empty is not unset.** electron-builder reads `CSC_LINK` as a path to the certificate. A GitHub expression that evaluates to nothing still *defines* the variable, so unsigned runs passed an empty string, which resolved to the project directory. `CSC_IDENTITY_AUTO_DISCOVERY: false` does not help, because an explicit `CSC_LINK` takes precedence over auto discovery.

**And the failure was silent.** The macOS build is piped through `sed` to redact the signing identity, and the default shell is `bash -e` *without* `pipefail`, so the step exited with sed's status rather than the build's. `shell: bash` supplies `pipefail`, so this class of failure now fails the step instead of surfacing as a missing artifact.

Reproduced locally (`⨯ ... not a file`) and confirmed fixed (`skipped macOS application code signing`, app builds).

Signed builds were unaffected, which is why the manual dispatch passed: it sets a real `CSC_LINK`. Only unsigned runs, meaning every push and pull request, hit this.